### PR TITLE
Add purple car to heatlegends

### DIFF
--- a/heat-legends/index.html
+++ b/heat-legends/index.html
@@ -22,6 +22,7 @@
         <div class="gray selector" color="gray"><img src="cars/gray.png" class="car"/></div>
         <div class="black selector" color="black"><img src="cars/black.png" class="car"/></div>
         <div class="orange selector" color="orange"><img src="cars/orange.png" class="car"/></div>
+        <div class="purple selector" color="purple"><img src="cars/purple.png" class="car"/></div>
     </div>
     <div id="inputs">
         <div class="flag-select-holder"></div>


### PR DESCRIPTION
- Added a purple car selector to the UI in `heat-legends/index.html`.
- The existing `purple.png` image is used.
- You can now select and add a purple car to the list of drivers.