### PR TITLE
feat: Display total speed and corner values for bots

### DIFF
--- a/heat-legends/index.html
+++ b/heat-legends/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
     <table id="drivers">
-        <tr class="heading"><td>Car</td><td>Driver</td><td></td><td>Speed</td><td>Over</td><td>Corner</td><td>&nbsp;</td></tr>
+        <tr class="heading"><td>Car</td><td>Driver</td><td></td><td>Speed</td><td>Over</td><td>Corner</td><th>Total Speed</th><th>Total Corner</th><td>&nbsp;</td></tr>
     </table>
     <div class="buttons"><div id="next" class="button">Move</div></div>
     <div class="add">

--- a/heat-legends/legends.css
+++ b/heat-legends/legends.css
@@ -234,3 +234,8 @@ img {
 #speed-plus:active, #corner-plus:active {
     background-color: rgb(24, 116, 197);
 }
+
+.total-speed, .total-corner {
+    text-align: center;
+    padding: 10px;
+}

--- a/heat-legends/legends.js
+++ b/heat-legends/legends.js
@@ -213,11 +213,14 @@ function custom_driver(color, name, nationality, speedDeck, overDeck, cornerDeck
         return draw(cornerDeck, cornerHand);
     };
 
+    driver.speedDeck = [...speedDeck]; // Create a copy
+    driver.cornerDeck = [...cornerDeck]; // Create a copy
+
     return driver;
 }
 
 function create_driver(driver) {
-    const e = $("<tr><td class='car'></td><td class='name'></td><td class='td-flag'><img class='flag'/></td><td class='max-speed'></td><td class='approach'></td><td class='corner'></td><td><div class='button remove'>Remove</div></td></tr>");
+    const e = $("<tr><td class='car'></td><td class='name'></td><td class='td-flag'><img class='flag'/></td><td class='max-speed'></td><td class='approach'></td><td class='corner'></td><td class='total-speed'></td><td class='total-corner'></td><td><div class='button remove'>Remove</div></td></tr>");
     e.attr("id", driver.color);
     e.addClass("driver");
     $('#drivers').append(e);
@@ -236,6 +239,14 @@ function create_driver(driver) {
     const remove = e.find(".remove");
 
     e.find(".name").text(driver.name);
+
+    // Calculate and display total speed
+    const totalSpeed = driver.speedDeck.reduce((sum, val) => sum + val, 0);
+    e.find(".total-speed").text(totalSpeed);
+
+    // Calculate and display total corner
+    const totalCorner = driver.cornerDeck.reduce((sum, val) => sum + val, 0);
+    e.find(".total-corner").text(totalCorner);
 
     remove.click(() => {
         if ($(this).hasClass("disabled")) return;


### PR DESCRIPTION
Adds columns for "Total Speed" and "Total Corner" to the drivers table in the heat legends interface.

- I modified `index.html` to include new table headers.
- I updated `legends.js`:
    - `custom_driver` now stores a copy of the speed and corner decks for each driver instance at the time of creation.
    - `create_driver` now calculates the sum of these stored decks and displays them in the new table cells for each driver.
- I added basic styling in `legends.css` for the new cells.

This allows you to see the specific total speed and corner capabilities assigned to each bot when it was added.