### PR TITLE
feat: Remove Total Speed and Total Corner from game view

### DIFF
--- a/heat-legends/index.html
+++ b/heat-legends/index.html
@@ -10,7 +10,7 @@
 </head>
 <body>
     <table id="drivers">
-        <tr class="heading"><td>Car</td><td>Driver</td><td></td><td>Speed</td><td>Over</td><td>Corner</td><th>Total Speed</th><th>Total Corner</th><td>&nbsp;</td></tr>
+        <tr class="heading"><td>Car</td><td>Driver</td><td></td><td>Speed</td><td>Over</td><td>Corner</td><td>&nbsp;</td></tr>
     </table>
     <div class="buttons"><div id="next" class="button">Move</div></div>
     <div class="add">

--- a/heat-legends/legends.js
+++ b/heat-legends/legends.js
@@ -220,7 +220,7 @@ function custom_driver(color, name, nationality, speedDeck, overDeck, cornerDeck
 }
 
 function create_driver(driver) {
-    const e = $("<tr><td class='car'></td><td class='name'></td><td class='td-flag'><img class='flag'/></td><td class='max-speed'></td><td class='approach'></td><td class='corner'></td><td class='total-speed'></td><td class='total-corner'></td><td><div class='button remove'>Remove</div></td></tr>");
+    const e = $("<tr><td class='car'></td><td class='name'></td><td class='td-flag'><img class='flag'/></td><td class='max-speed'></td><td class='approach'></td><td class='corner'></td><td><div class='button remove'>Remove</div></td></tr>");
     e.attr("id", driver.color);
     e.addClass("driver");
     $('#drivers').append(e);
@@ -239,14 +239,6 @@ function create_driver(driver) {
     const remove = e.find(".remove");
 
     e.find(".name").text(driver.name);
-
-    // Calculate and display total speed
-    const totalSpeed = driver.speedDeck.reduce((sum, val) => sum + val, 0);
-    e.find(".total-speed").text(totalSpeed);
-
-    // Calculate and display total corner
-    const totalCorner = driver.cornerDeck.reduce((sum, val) => sum + val, 0);
-    e.find(".total-corner").text(totalCorner);
 
     remove.click(() => {
         if ($(this).hasClass("disabled")) return;


### PR DESCRIPTION
Removes the "Total Speed" and "Total Corner" columns from the driver table to simplify the UI.

- Removes the table headers from `heat-legends/index.html`.
- Removes the corresponding table data cells and the calculation logic from `heat-legends/legends.js`.