### PR TITLE
⚡ Bolt: Cache hull polygon for collision optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,7 +134,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -176,7 +175,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/regatta/js/script.js
+++ b/regatta/js/script.js
@@ -3696,6 +3696,9 @@ function updateBoat(boat, dt) {
     boat.raceState.lastPos.x = boat.x;
     boat.raceState.lastPos.y = boat.y;
     boat.prevHeading = boat.heading;
+
+    // Invalidate Collision Cache (Will be recomputed if needed this frame)
+    boat.collisionPoly = null;
 }
 
 function updateBoatRaceState(boat, dt) {
@@ -3965,7 +3968,7 @@ function updateBoatRaceState(boat, dt) {
 }
 
 // Collision Helpers
-function getHullPolygon(boat) {
+function computeHullPolygon(boat) {
     const locals = [
         {x: 0, y: -25}, {x: 15, y: -5}, {x: 15, y: 20},
         {x: 12, y: 30}, {x: -12, y: 30}, {x: -15, y: 20}, {x: -15, y: -5}
@@ -3975,6 +3978,13 @@ function getHullPolygon(boat) {
         x: boat.x + (p.x * cos - p.y * sin),
         y: boat.y + (p.x * sin + p.y * cos)
     }));
+}
+
+function getHullPolygon(boat) {
+    if (!boat.collisionPoly) {
+        boat.collisionPoly = computeHullPolygon(boat);
+    }
+    return boat.collisionPoly;
 }
 
 function projectPolygon(axis, poly) {


### PR DESCRIPTION
This PR optimizes the collision detection loop in the Regatta game by caching the hull polygon vertices for each boat.

**Changes:**
- `regatta/js/script.js`:
    - Renamed `getHullPolygon` to `computeHullPolygon`.
    - Implemented a caching `getHullPolygon` that stores the result on the `boat` object.
    - Added `boat.collisionPoly = null` in `updateBoat` to invalidate the cache once per frame after physics integration.

**Impact:**
- Reduces the number of polygon computations (trigonometry + array allocation) from ~O(N^2) to O(N) per frame during collision checks.
- For 10 boats, this reduces calls from ~55+ to 10 per frame.

**Verification:**
- Ran `npm run eval:ai` (10 trials) which simulates full races including collisions.
- Confirmed simulation completes successfully with expected metrics.


---
*PR created automatically by Jules for task [5685398903609316114](https://jules.google.com/task/5685398903609316114) started by @wesdyer*