### PR TITLE
⚡ Bolt: Optimize wind calculation physics

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Optimizing Wind Simulation
+**Learning:** In highly iterative simulation loops like `getWindAt` (called per-frame/per-particle), avoiding `Math.sqrt` via squared-distance checks and caching trigonometric values (`sin`/`cos`) on the entity (gusts) provided a measurable performance boost without altering logic.
+**Action:** Always inspect frequently called physics functions for redundant trig/sqrts and implement caching on the update cycle.


### PR DESCRIPTION
- Pre-calculates `sin` and `cos` values for wind gusts during creation and update, avoiding repeated `Math.sin/cos` calls in `getWindAt`.
- Adds a squared-distance check (`maxRadiusSq`) to `getWindAt` for faster early rejection before checking individual gust influence.
- Reduces computational overhead in the main game loop, as `getWindAt` is called frequently.


---
*PR created automatically by Jules for task [1821357048398862960](https://jules.google.com/task/1821357048398862960) started by @wesdyer*