### PR TITLE
🎨 Palette: Improve accessibility of Wordle inputs and buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Adding focus styles and ARIA labels for buttons in Wordle
+**Learning:** Virtual keyboards generated dynamically need ARIA labels for non-alphabetic keys (Enter, Backspace), and all interactive elements including custom radio buttons (`.sr-only` instead of `.invisible`) need explicit `focus-visible` styles to be usable via keyboard navigation.
+**Action:** When creating custom styled inputs or icon-only buttons, ensure to add screen reader support (`aria-label`) and visible keyboard focus indicators (`focus-visible`). Avoid using `invisible` for inputs if they should still receive focus and be readable by screen readers.

--- a/wordle/index.html
+++ b/wordle/index.html
@@ -69,23 +69,23 @@
 <header class="flex items-center px-4 py-3 justify-between border-b border-neutral-100 sticky top-0 z-10 bg-white/95 backdrop-blur-sm">
 <div class="size-10 shrink-0"></div>
 <h1 class="text-2xl md:text-3xl font-extrabold tracking-tight text-center flex-1">Endless Wordle</h1>
-<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary">
+<button aria-label="Statistics" class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 focus-visible:bg-neutral-100 focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:outline-none transition-colors text-text-primary">
 <span class="material-symbols-outlined text-[24px]">bar_chart</span>
 </button>
 </header>
 <div class="px-6 py-4">
 <div class="flex h-10 w-full items-center justify-center rounded-xl bg-neutral-100 p-1">
-<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200">
+<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-neutral-400">
 <span class="truncate text-xs font-bold uppercase tracking-wide">Easy</span>
-<input class="invisible w-0 absolute" name="difficulty" type="radio" value="Easy"/>
+<input class="sr-only" name="difficulty" type="radio" value="Easy"/>
 </label>
-<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200">
+<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-neutral-400">
 <span class="truncate text-xs font-bold uppercase tracking-wide">Medium</span>
-<input checked="" class="invisible w-0 absolute" name="difficulty" type="radio" value="Medium"/>
+<input checked="" class="sr-only" name="difficulty" type="radio" value="Medium"/>
 </label>
-<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200">
+<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-neutral-400">
 <span class="truncate text-xs font-bold uppercase tracking-wide">Hard</span>
-<input class="invisible w-0 absolute" name="difficulty" type="radio" value="Hard"/>
+<input class="sr-only" name="difficulty" type="radio" value="Hard"/>
 </label>
 </div>
 </div>
@@ -103,8 +103,8 @@
     <div class="bg-white rounded-lg shadow-xl w-full max-w-md mx-auto flex flex-col max-h-full">
         <div class="flex justify-between items-center p-6 border-b shrink-0">
             <h2 class="text-2xl font-bold">Statistics</h2>
-            <button id="close-stats" class="text-gray-500 hover:text-gray-800">
-                <span class="material-symbols-outlined">close</span>
+            <button id="close-stats" aria-label="Close statistics" class="text-gray-500 hover:text-gray-800 rounded-full p-1 focus-visible:bg-neutral-100 focus-visible:ring-2 focus-visible:ring-neutral-400 focus-visible:outline-none transition-colors">
+                <span class="material-symbols-outlined block">close</span>
             </button>
         </div>
         <div id="stats-content" class="p-6 overflow-y-auto"></div>

--- a/wordle/script.js
+++ b/wordle/script.js
@@ -196,7 +196,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const newGameBtn = document.createElement('button');
         newGameBtn.id = 'new-game-btn';
         newGameBtn.textContent = 'New Game';
-        newGameBtn.className = 'h-14 w-full rounded bg-correct text-white text-lg font-bold flex items-center justify-center transition-colors uppercase';
+        newGameBtn.className = 'h-14 w-full rounded bg-correct focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-correct focus-visible:outline-none text-white text-lg font-bold flex items-center justify-center transition-colors uppercase';
         newGameBtn.addEventListener('click', () => init(true));
         keyboard.appendChild(newGameBtn);
     }
@@ -269,25 +269,28 @@ document.addEventListener('DOMContentLoaded', () => {
             row.split('-').forEach(keyGroup => {
                 if (keyGroup === 'ENTER') {
                     const enterBtn = document.createElement('button');
-                    enterBtn.className = 'h-14 w-[15%] rounded bg-key-bg hover:bg-neutral-300 active:bg-neutral-400 text-key-text text-[12px] font-bold flex items-center justify-center transition-colors uppercase';
+                    enterBtn.className = 'h-14 w-[15%] rounded bg-key-bg hover:bg-neutral-300 active:bg-neutral-400 focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:outline-none text-key-text text-[12px] font-bold flex items-center justify-center transition-colors uppercase';
                     enterBtn.textContent = 'Enter';
                     enterBtn.dataset.key = 'Enter';
+                    enterBtn.ariaLabel = 'Enter';
                     rowDiv.appendChild(enterBtn);
                 } else if (keyGroup === 'BACKSPACE') {
                     const backspaceBtn = document.createElement('button');
-                    backspaceBtn.className = 'h-14 w-[15%] rounded bg-key-bg hover:bg-neutral-300 active:bg-neutral-400 text-key-text text-sm font-bold flex items-center justify-center transition-colors';
+                    backspaceBtn.className = 'h-14 w-[15%] rounded bg-key-bg hover:bg-neutral-300 active:bg-neutral-400 focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:outline-none text-key-text text-sm font-bold flex items-center justify-center transition-colors';
                     const span = document.createElement('span');
                     span.className = 'material-symbols-outlined text-[20px]';
                     span.textContent = 'backspace';
                     backspaceBtn.dataset.key = 'Backspace';
+                    backspaceBtn.ariaLabel = 'Backspace';
                     backspaceBtn.appendChild(span);
                     rowDiv.appendChild(backspaceBtn);
                 } else {
                     keyGroup.split('').forEach(key => {
                         const keyBtn = document.createElement('button');
-                        keyBtn.className = 'h-14 flex-1 rounded bg-key-bg hover:bg-neutral-300 active:bg-neutral-400 text-key-text text-[13px] font-bold flex items-center justify-center transition-colors';
+                        keyBtn.className = 'h-14 flex-1 rounded bg-key-bg hover:bg-neutral-300 active:bg-neutral-400 focus-visible:ring-2 focus-visible:ring-neutral-500 focus-visible:outline-none text-key-text text-[13px] font-bold flex items-center justify-center transition-colors';
                         keyBtn.textContent = key;
                         keyBtn.dataset.key = key;
+                        keyBtn.ariaLabel = key;
                         rowDiv.appendChild(keyBtn);
                     });
                 }


### PR DESCRIPTION
🎨 Palette: [Accessibility improvements to Wordle inputs and buttons]

💡 **What:** 
- Added `aria-label` attributes to the icon-only "Statistics" and "Close" buttons.
- Added `aria-label` to the dynamically generated "Enter" and "Backspace" keys on the virtual keyboard.
- Replaced the `.invisible` class with `.sr-only` on the difficulty radio button inputs. 
- Added explicit `.focus-visible` styling to all buttons and radio inputs.
- Recorded a learning on `.jules/palette.md` to establish a convention for future virtual keyboards and custom inputs.

🎯 **Why:** 
- The icon-only buttons lacked descriptive labels, making them unclear to screen reader users.
- The `invisible` class on the radio buttons completely removes them from the accessibility tree, meaning screen readers ignore them and they cannot naturally receive focus. `.sr-only` visually hides them but keeps them interactive.
- The buttons lacked clear focus indicators, making the application difficult or impossible to navigate via keyboard. 

♿ **Accessibility:** 
- Improves keyboard navigation by providing clear visual focus states.
- Improves screen reader support by ensuring all interactive elements have labels and remain in the accessibility tree.

---
*PR created automatically by Jules for task [8440499198347714349](https://jules.google.com/task/8440499198347714349) started by @wesdyer*