### PR TITLE
⚡ Bolt: [Performance] Cache global wind trigonometric values in getWindAt

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-XX - [Regatta getWindAt trigonometric optimization]
+**Learning:** High-frequency functions like `getWindAt` in the physics loop can become bottlenecks due to redundant trigonometric calculations (Math.sin, Math.cos) for static or slowly changing values like base wind direction. Caching these values per-update avoids millions of redundant math operations per trial.
+**Action:** Always look for sine/cosine calculations inside tight loops (like iterating over boats, gusts, or pixels) that depend on variables outside the loop. Cache these values at the source of the update rather than recalculating them on demand.

--- a/regatta/js/script.js
+++ b/regatta/js/script.js
@@ -1685,6 +1685,10 @@ function updateBaseWind(dt) {
     state.wind.currentShift = newShiftDeg * (Math.PI / 180);
     state.wind.direction = normalizeAngle(state.wind.baseDirection + state.wind.currentShift);
 
+    // Cache base direction sine/cosine for getWindAt
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
+
     // Variability (Speed)
     const v = cond.variability !== undefined ? cond.variability : 0.5;
     const varPct = 0.05 + v * 0.25;
@@ -2012,6 +2016,16 @@ function updateGusts(dt) {
         g.radiusX = Math.max(10, g.maxRadiusX * lifeFactor);
         g.radiusY = Math.max(10, g.maxRadiusY * lifeFactor);
 
+        // Cache computationally expensive values for getWindAt
+        g.cosRot = Math.cos(-g.rotation);
+        g.sinRot = Math.sin(-g.rotation);
+        g.invRadiusXSq = 1 / (g.radiusX * g.radiusX);
+        g.invRadiusYSq = 1 / (g.radiusY * g.radiusY);
+
+        const gwDir = globalWindDir + g.dirDelta;
+        g.sinGwDir = Math.sin(gwDir);
+        g.cosGwDir = Math.cos(gwDir);
+
         if (g.age > g.duration) {
             state.gusts.splice(i, 1);
         }
@@ -2021,21 +2035,18 @@ function updateGusts(dt) {
 function getWindAt(x, y) {
     // Current Global Wind
     const baseSpeed = state.wind.speed;
-    const baseDir = state.wind.direction;
 
-    // Convert to vector
-    let sumWx = Math.sin(baseDir) * baseSpeed;
-    let sumWy = -Math.cos(baseDir) * baseSpeed;
+    // Convert to vector using cached sine/cosine
+    let sumWx = state.wind.sinDir * baseSpeed;
+    let sumWy = -state.wind.cosDir * baseSpeed;
 
     for (const g of state.gusts) {
         const dx = x - g.x;
         const dy = y - g.y;
-        const cos = Math.cos(-g.rotation);
-        const sin = Math.sin(-g.rotation);
-        const rx = dx * cos - dy * sin;
-        const ry = dx * sin + dy * cos;
+        const rx = dx * g.cosRot - dy * g.sinRot;
+        const ry = dx * g.sinRot + dy * g.cosRot;
 
-        const distSq = (rx*rx)/(g.radiusX*g.radiusX) + (ry*ry)/(g.radiusY*g.radiusY);
+        const distSq = (rx * rx) * g.invRadiusXSq + (ry * ry) * g.invRadiusYSq;
         if (distSq <= 1) {
             const falloff = 1 - Math.sqrt(distSq);
             const lifeFade = Math.min(g.age / 5, 1) * Math.min((g.duration - g.age) / 5, 1);
@@ -2043,13 +2054,10 @@ function getWindAt(x, y) {
 
             if (intensity > 0) {
                  const gSpeed = g.speedDelta * intensity;
-                 // Local direction inside puff
-                 const gwDir = baseDir + g.dirDelta;
-
-                 // Add puff vector
+                 // Add puff vector using precalculated direction sine/cosine
                  // Note: gSpeed can be negative (lull)
-                 sumWx += Math.sin(gwDir) * gSpeed;
-                 sumWy += -Math.cos(gwDir) * gSpeed;
+                 sumWx += g.sinGwDir * gSpeed;
+                 sumWy += -g.cosGwDir * gSpeed;
             }
         }
     }
@@ -2992,6 +3000,10 @@ if (UI.confIslandClustering) {
             const offset = state.race.conditions.directionBias || 0;
             state.wind.baseDirection = normalizeAngle(targetRad + offset);
             state.wind.direction = state.wind.baseDirection;
+
+            // Cache base direction sine/cosine for getWindAt
+            state.wind.sinDir = Math.sin(state.wind.direction);
+            state.wind.cosDir = Math.cos(state.wind.direction);
 
             // Re-init course to align with new wind
             initCourse();
@@ -7070,6 +7082,8 @@ function resetGame() {
     state.wind.speed = state.wind.baseSpeed;
     state.wind.baseDirection = Math.random() * Math.PI * 2;
     state.wind.direction = state.wind.baseDirection;
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
     state.wind.currentShift = 0;
     state.wind.oscillator = Math.random() * Math.PI * 2; // Random phase
     state.wind.history = [];


### PR DESCRIPTION
💡 **What**:
The `getWindAt` function is a hot path called incredibly frequently (for every boat, multiple times per frame, plus particles/waves). It previously contained several redundant and expensive mathematical calculations:
- Recalculating `Math.sin` and `Math.cos` for the global wind direction on every call.
- Recalculating `Math.sin` and `Math.cos` for gust rotations and internal directions.
- Recalculating division and squaring `1 / (radius * radius)` for gust falloff logic.

This PR caches these values. Global wind direction sine/cosine are updated in `updateBaseWind`, `resetGame`, and UI handlers. Gust calculations are pre-computed in `updateGusts`.

🎯 **Why**:
Because `getWindAt` runs in such a tight physics/rendering loop, performing unnecessary trigonometric operations per-call limits the performance ceiling and framerate on lower-end hardware, slowing down evaluations as well. 

📊 **Impact**:
Eliminates hundreds of thousands of redundant math operations per trial.

🔬 **Measurement**:
Verified stability and correctness using `pnpm run eval:ai`.

---
*PR created automatically by Jules for task [4697269585542771762](https://jules.google.com/task/4697269585542771762) started by @wesdyer*