### PR TITLE
⚡ Bolt: Cache trigonometric calculations in getWindAt

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Trigonometric Function Caching in High-Frequency Physics Methods
+**Learning:** In the `regatta` application, trigonometric functions (`Math.sin`, `Math.cos`) and division operations (`/`) within high-frequency physics queries like `getWindAt` (which is called per frame by every boat, AI projection, and visible wind wave) can create significant performance bottlenecks.
+**Action:** Always pre-calculate and cache trigonometric values (e.g., `sinDir`, `cosDir`, `sinRot`, `cosRot`) and inverse values for division (e.g., `invRadiusXSq = 1 / (r * r)`) when the underlying properties (`direction`, `rotation`, `radius`) are updated, rather than recalculating them on the fly in `getWindAt`.

--- a/regatta/js/script.js
+++ b/regatta/js/script.js
@@ -1684,6 +1684,8 @@ function updateBaseWind(dt) {
 
     state.wind.currentShift = newShiftDeg * (Math.PI / 180);
     state.wind.direction = normalizeAngle(state.wind.baseDirection + state.wind.currentShift);
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
 
     // Variability (Speed)
     const v = cond.variability !== undefined ? cond.variability : 0.5;
@@ -2012,6 +2014,15 @@ function updateGusts(dt) {
         g.radiusX = Math.max(10, g.maxRadiusX * lifeFactor);
         g.radiusY = Math.max(10, g.maxRadiusY * lifeFactor);
 
+        // Pre-calculate expensive math for getWindAt
+        g.sinRot = Math.sin(-g.rotation);
+        g.cosRot = Math.cos(-g.rotation);
+        g.invRadiusXSq = 1 / (g.radiusX * g.radiusX);
+        g.invRadiusYSq = 1 / (g.radiusY * g.radiusY);
+        const gwDir = state.wind.direction + g.dirDelta;
+        g.sinGwDir = Math.sin(gwDir);
+        g.cosGwDir = Math.cos(gwDir);
+
         if (g.age > g.duration) {
             state.gusts.splice(i, 1);
         }
@@ -2021,21 +2032,21 @@ function updateGusts(dt) {
 function getWindAt(x, y) {
     // Current Global Wind
     const baseSpeed = state.wind.speed;
-    const baseDir = state.wind.direction;
 
-    // Convert to vector
-    let sumWx = Math.sin(baseDir) * baseSpeed;
-    let sumWy = -Math.cos(baseDir) * baseSpeed;
+    // Convert to vector using pre-calculated trig values
+    let sumWx = state.wind.sinDir * baseSpeed;
+    let sumWy = -state.wind.cosDir * baseSpeed;
 
     for (const g of state.gusts) {
         const dx = x - g.x;
         const dy = y - g.y;
-        const cos = Math.cos(-g.rotation);
-        const sin = Math.sin(-g.rotation);
-        const rx = dx * cos - dy * sin;
-        const ry = dx * sin + dy * cos;
 
-        const distSq = (rx*rx)/(g.radiusX*g.radiusX) + (ry*ry)/(g.radiusY*g.radiusY);
+        // Use pre-calculated values
+        const rx = dx * g.cosRot - dy * g.sinRot;
+        const ry = dx * g.sinRot + dy * g.cosRot;
+
+        const distSq = (rx * rx * g.invRadiusXSq) + (ry * ry * g.invRadiusYSq);
+
         if (distSq <= 1) {
             const falloff = 1 - Math.sqrt(distSq);
             const lifeFade = Math.min(g.age / 5, 1) * Math.min((g.duration - g.age) / 5, 1);
@@ -2043,13 +2054,10 @@ function getWindAt(x, y) {
 
             if (intensity > 0) {
                  const gSpeed = g.speedDelta * intensity;
-                 // Local direction inside puff
-                 const gwDir = baseDir + g.dirDelta;
 
-                 // Add puff vector
-                 // Note: gSpeed can be negative (lull)
-                 sumWx += Math.sin(gwDir) * gSpeed;
-                 sumWy += -Math.cos(gwDir) * gSpeed;
+                 // Add puff vector using pre-calculated trig values
+                 sumWx += g.sinGwDir * gSpeed;
+                 sumWy += -g.cosGwDir * gSpeed;
             }
         }
     }
@@ -2992,6 +3000,8 @@ if (UI.confIslandClustering) {
             const offset = state.race.conditions.directionBias || 0;
             state.wind.baseDirection = normalizeAngle(targetRad + offset);
             state.wind.direction = state.wind.baseDirection;
+            state.wind.sinDir = Math.sin(state.wind.direction);
+            state.wind.cosDir = Math.cos(state.wind.direction);
 
             // Re-init course to align with new wind
             initCourse();
@@ -7070,6 +7080,8 @@ function resetGame() {
     state.wind.speed = state.wind.baseSpeed;
     state.wind.baseDirection = Math.random() * Math.PI * 2;
     state.wind.direction = state.wind.baseDirection;
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
     state.wind.currentShift = 0;
     state.wind.oscillator = Math.random() * Math.PI * 2; // Random phase
     state.wind.history = [];


### PR DESCRIPTION
💡 What: The optimization implemented
Pre-calculated and cached the results of `Math.sin`, `Math.cos`, and `1 / r^2` for both the global wind and individual gusts when they are updated, rather than re-calculating them every time `getWindAt` is called.

🎯 Why: The performance problem it solves
The `getWindAt` function is a "hot path" queried at a very high frequency by the simulation loop (multiple times per frame for boats, projections, and wind waves). Running trigonometric functions and division operations inside this function creates a significant computational bottleneck.

📊 Impact: Expected performance improvement
Significantly reduces the CPU overhead per frame by substituting complex mathematical operations with simple vector multiplication and addition.

🔬 Measurement: How to verify the improvement
Run `pnpm run eval:ai` to verify that the simulation logic and AI behavior remain perfectly consistent and stable with the new caching approach.

---
*PR created automatically by Jules for task [16204846391292656460](https://jules.google.com/task/16204846391292656460) started by @wesdyer*