### PR TITLE
🎨 Palette: Add ARIA label to clear button in solver

### DIFF
--- a/solver/index.html
+++ b/solver/index.html
@@ -57,7 +57,7 @@
             </section>
         </main>
     </div>
-    <button id="clear-button" class="hidden fixed bottom-10 right-10 bg-gray-800 hover:bg-gray-900 text-white p-4 rounded-full shadow-lg">
+    <button id="clear-button" aria-label="Clear grid" title="Clear grid" class="hidden fixed bottom-10 right-10 bg-gray-800 hover:bg-gray-900 text-white p-4 rounded-full shadow-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-gray-800">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
     </button>
     <input type="text" id="hidden-input" style="position: absolute; top: -9999px; left: -9999px;">


### PR DESCRIPTION
🎨 Palette: Add ARIA label and focus styles to solver clear button

**💡 What:** Added `aria-label="Clear grid"`, `title="Clear grid"`, and `focus-visible:ring-2` to the icon-only clear button in the Wordle solver.
**🎯 Why:** The clear button previously lacked text content or tooltips, making it opaque to screen readers and difficult for keyboard users to identify when focused.
**♿ Accessibility:** Improves screen reader compatibility (ARIA label), mouse usability (title tooltip), and keyboard navigation visibility (focus rings).

---
*PR created automatically by Jules for task [4242922123596384255](https://jules.google.com/task/4242922123596384255) started by @wesdyer*