### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons in Minesweeper

### DIFF
--- a/mines/index.html
+++ b/mines/index.html
@@ -63,10 +63,10 @@
 <h1 class="text-xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-500 to-purple-500 dark:from-indigo-300 dark:to-purple-300">Minesweeper</h1>
 </div>
 <div class="flex items-center gap-2">
-<button id="music-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group" aria-label="Toggle Music">
+<button id="music-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group" aria-label="Toggle Music" title="Toggle Music">
 <span class="material-symbols-outlined group-hover:scale-110 transition-transform">music_off</span>
 </button>
-<button id="sound-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group" aria-label="Toggle Sound">
+<button id="sound-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group" aria-label="Toggle Sound" title="Toggle Sound">
 <span class="material-symbols-outlined group-hover:scale-110 transition-transform">volume_up</span>
 </button>
 </div>
@@ -102,10 +102,10 @@
 <div class="mt-2 text-xs font-bold text-indigo-300/80 uppercase tracking-wider">Best: <span id="best-time-display" class="text-green-400">--:--</span></div>
 </div>
 <div class="flex items-center gap-4 z-10">
-<button id="smiley-button" class="size-16 rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 hover:from-yellow-300 hover:to-orange-400 border-t border-yellow-200 shadow-[0_4px_0_0_#b45309] active:shadow-none active:translate-y-1 active:border-none flex items-center justify-center transform transition-all group">
+<button id="smiley-button" class="size-16 rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 hover:from-yellow-300 hover:to-orange-400 border-t border-yellow-200 shadow-[0_4px_0_0_#b45309] active:shadow-none active:translate-y-1 active:border-none focus-visible:ring-2 focus-visible:ring-yellow-500 focus-visible:outline-none flex items-center justify-center transform transition-all group" aria-label="Restart Game" title="Restart Game">
 <span class="material-symbols-outlined text-4xl text-white drop-shadow-md">sentiment_satisfied</span>
 </button>
-<button id="cascade-button" class="size-16 rounded-2xl bg-gradient-to-b from-blue-400 to-cyan-500 hover:from-blue-300 hover:to-cyan-400 border-t border-blue-200 shadow-[0_4px_0_0_#0369a1] active:shadow-none active:translate-y-1 active:border-none flex items-center justify-center transform transition-all group">
+<button id="cascade-button" class="size-16 rounded-2xl bg-gradient-to-b from-blue-400 to-cyan-500 hover:from-blue-300 hover:to-cyan-400 border-t border-blue-200 shadow-[0_4px_0_0_#0369a1] active:shadow-none active:translate-y-1 active:border-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:outline-none flex items-center justify-center transform transition-all group" aria-label="Cascade" title="Cascade">
 <span class="material-symbols-outlined text-4xl text-white drop-shadow-md">auto_awesome</span>
 </button>
 </div>


### PR DESCRIPTION
💡 **What**: Added `aria-label`, `title`, and `focus-visible` utility classes to the four icon-only buttons (`music-toggle`, `sound-toggle`, `smiley-button`, `cascade-button`) in the Minesweeper application (`mines/index.html`).
🎯 **Why**: To ensure these buttons are properly announced by screen readers, provide native tooltips for visual users, and have clear visible focus states for keyboard-only users.
♿ **Accessibility**: Improved keyboard navigation and screen reader support for critical game controls.

---
*PR created automatically by Jules for task [14552293325812122632](https://jules.google.com/task/14552293325812122632) started by @wesdyer*