### PR TITLE
🎨 Palette: Add accessibility attributes and focus states to Mines icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-05-14 - Icon-Only Buttons Accessibility
+
+**Learning:** When using custom icon buttons (like `music-toggle`, `sound-toggle`, `smiley-button`, `cascade-button` in the `mines` app), it is important to include BOTH `aria-label` and `title` attributes for full accessibility (screen readers and tooltips), as well as explicit keyboard focus rings (e.g., `focus-visible:ring-2`) since the default browser focus ring might be removed by Tailwind utilities like `outline-none` or custom active states.
+
+**Action:** Ensure that any future icon-only buttons added to the project receive `aria-label`, `title`, and explicit `:focus-visible` styling using Tailwind CSS.

--- a/mines/index.html
+++ b/mines/index.html
@@ -63,10 +63,10 @@
 <h1 class="text-xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-r from-indigo-500 to-purple-500 dark:from-indigo-300 dark:to-purple-300">Minesweeper</h1>
 </div>
 <div class="flex items-center gap-2">
-<button id="music-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group" aria-label="Toggle Music">
+<button id="music-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900" aria-label="Toggle Music" title="Toggle Music">
 <span class="material-symbols-outlined group-hover:scale-110 transition-transform">music_off</span>
 </button>
-<button id="sound-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group" aria-label="Toggle Sound">
+<button id="sound-toggle" class="size-10 rounded-xl bg-surface-dark border border-indigo-500/20 hover:bg-indigo-500/20 text-indigo-400 hover:text-indigo-300 transition-colors flex items-center justify-center group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900" aria-label="Toggle Sound" title="Toggle Sound">
 <span class="material-symbols-outlined group-hover:scale-110 transition-transform">volume_up</span>
 </button>
 </div>
@@ -102,10 +102,10 @@
 <div class="mt-2 text-xs font-bold text-indigo-300/80 uppercase tracking-wider">Best: <span id="best-time-display" class="text-green-400">--:--</span></div>
 </div>
 <div class="flex items-center gap-4 z-10">
-<button id="smiley-button" class="size-16 rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 hover:from-yellow-300 hover:to-orange-400 border-t border-yellow-200 shadow-[0_4px_0_0_#b45309] active:shadow-none active:translate-y-1 active:border-none flex items-center justify-center transform transition-all group">
+<button id="smiley-button" class="size-16 rounded-2xl bg-gradient-to-b from-yellow-400 to-orange-500 hover:from-yellow-300 hover:to-orange-400 border-t border-yellow-200 shadow-[0_4px_0_0_#b45309] active:shadow-none active:translate-y-1 active:border-none flex items-center justify-center transform transition-all group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900" aria-label="Restart Game" title="Restart Game">
 <span class="material-symbols-outlined text-4xl text-white drop-shadow-md">sentiment_satisfied</span>
 </button>
-<button id="cascade-button" class="size-16 rounded-2xl bg-gradient-to-b from-blue-400 to-cyan-500 hover:from-blue-300 hover:to-cyan-400 border-t border-blue-200 shadow-[0_4px_0_0_#0369a1] active:shadow-none active:translate-y-1 active:border-none flex items-center justify-center transform transition-all group">
+<button id="cascade-button" class="size-16 rounded-2xl bg-gradient-to-b from-blue-400 to-cyan-500 hover:from-blue-300 hover:to-cyan-400 border-t border-blue-200 shadow-[0_4px_0_0_#0369a1] active:shadow-none active:translate-y-1 active:border-none flex items-center justify-center transform transition-all group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-900" aria-label="Use Cascade" title="Use Cascade">
 <span class="material-symbols-outlined text-4xl text-white drop-shadow-md">auto_awesome</span>
 </button>
 </div>


### PR DESCRIPTION
This PR improves the accessibility of the icon-only buttons in the Minesweeper clone by adding appropriate ARIA labels, hover titles, and explicit keyboard focus states.

---
*PR created automatically by Jules for task [12838168121082904377](https://jules.google.com/task/12838168121082904377) started by @wesdyer*