### PR TITLE
🎨 Palette: Improve accessibility of icon-only buttons in Solver and Wordle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-28 - Focus Rings for Icon-Only Buttons
+**Learning:** Adding `focus-visible` to icon-only buttons built with Tailwind is critical to ensure keyboard users see a clear focus indicator, especially when `outline-none` might otherwise remove default focus styles. Combining this with `aria-label` provides a robust, accessible component for both screen readers and keyboard navigation.
+**Action:** Always ensure that any interactive element missing visible text has an explicit `focus-visible` utility class (e.g., `focus-visible:ring-2`) and an `aria-label`.

--- a/solver/index.html
+++ b/solver/index.html
@@ -57,7 +57,7 @@
             </section>
         </main>
     </div>
-    <button id="clear-button" class="hidden fixed bottom-10 right-10 bg-gray-800 hover:bg-gray-900 text-white p-4 rounded-full shadow-lg">
+    <button id="clear-button" class="hidden fixed bottom-10 right-10 bg-gray-800 hover:bg-gray-900 text-white p-4 rounded-full shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2" aria-label="Clear grid" title="Clear grid">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>
     </button>
     <input type="text" id="hidden-input" style="position: absolute; top: -9999px; left: -9999px;">

--- a/wordle/index.html
+++ b/wordle/index.html
@@ -69,7 +69,7 @@
 <header class="flex items-center px-4 py-3 justify-between border-b border-neutral-100 sticky top-0 z-10 bg-white/95 backdrop-blur-sm">
 <div class="size-10 shrink-0"></div>
 <h1 class="text-2xl md:text-3xl font-extrabold tracking-tight text-center flex-1">Endless Wordle</h1>
-<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary">
+<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary focus-visible:outline-none focus-visible:ring-2" aria-label="Statistics">
 <span class="material-symbols-outlined text-[24px]">bar_chart</span>
 </button>
 </header>
@@ -103,7 +103,7 @@
     <div class="bg-white rounded-lg shadow-xl w-full max-w-md mx-auto flex flex-col max-h-full">
         <div class="flex justify-between items-center p-6 border-b shrink-0">
             <h2 class="text-2xl font-bold">Statistics</h2>
-            <button id="close-stats" class="text-gray-500 hover:text-gray-800">
+            <button id="close-stats" class="text-gray-500 hover:text-gray-800 focus-visible:outline-none focus-visible:ring-2" aria-label="Close statistics">
                 <span class="material-symbols-outlined">close</span>
             </button>
         </div>


### PR DESCRIPTION
## 💡 What: 
Added `aria-label` attributes and `focus-visible` Tailwind classes to icon-only buttons in the solver and wordle applications.

## 🎯 Why: 
Icon-only buttons rely on screen readers and keyboard navigation. Without an `aria-label`, screen readers may announce them as "button" with no context. Without a focus ring, keyboard users cannot easily determine which button has focus. 

## ♿ Accessibility:
- Added `aria-label="Clear grid"` to the solver's clear button
- Added `aria-label="Statistics"` to the wordle's stats button
- Added `aria-label="Close statistics"` to the wordle's stats modal close button
- Ensured all the above buttons have `focus-visible:ring-2` to visually indicate keyboard focus.

---
*PR created automatically by Jules for task [1864289405317613774](https://jules.google.com/task/1864289405317613774) started by @wesdyer*