### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels and focus states to Wordle icon buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-28 - Adding ARIA labels and focus-visible classes to icon-only buttons
+**Learning:** Icon-only buttons frequently miss critical accessibility features. Specifically, screen readers need `aria-label` attributes to understand the button's purpose, and keyboard navigation requires visible focus indicators (like Tailwind's `focus-visible:ring-2`) since default styles are often removed.
+**Action:** When inspecting or adding icon-only buttons, consistently ensure `aria-label`, `title`, and `focus-visible` utility classes are present.

--- a/wordle/index.html
+++ b/wordle/index.html
@@ -69,7 +69,7 @@
 <header class="flex items-center px-4 py-3 justify-between border-b border-neutral-100 sticky top-0 z-10 bg-white/95 backdrop-blur-sm">
 <div class="size-10 shrink-0"></div>
 <h1 class="text-2xl md:text-3xl font-extrabold tracking-tight text-center flex-1">Endless Wordle</h1>
-<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary">
+<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary focus-visible:ring-2 focus-visible:ring-offset-2 outline-none" aria-label="Statistics" title="Statistics">
 <span class="material-symbols-outlined text-[24px]">bar_chart</span>
 </button>
 </header>
@@ -103,7 +103,7 @@
     <div class="bg-white rounded-lg shadow-xl w-full max-w-md mx-auto flex flex-col max-h-full">
         <div class="flex justify-between items-center p-6 border-b shrink-0">
             <h2 class="text-2xl font-bold">Statistics</h2>
-            <button id="close-stats" class="text-gray-500 hover:text-gray-800">
+            <button id="close-stats" class="text-gray-500 hover:text-gray-800 focus-visible:ring-2 focus-visible:ring-offset-2 outline-none rounded" aria-label="Close Statistics" title="Close Statistics">
                 <span class="material-symbols-outlined">close</span>
             </button>
         </div>


### PR DESCRIPTION
💡 **What:** Added `aria-label`, `title`, and `focus-visible` Tailwind classes to the 'Statistics' button in the header and the 'Close' button in the statistics modal of the Wordle application.
🎯 **Why:** To make these icon-only buttons accessible to screen readers and ensure clear visual feedback for users navigating with a keyboard.
♿ **Accessibility:** Provides necessary context for assistive technologies and restores keyboard focus visibility that may be suppressed by other styles.

---
*PR created automatically by Jules for task [3759596563874593190](https://jules.google.com/task/3759596563874593190) started by @wesdyer*