### PR TITLE
🎨 Palette: Wordle Accessibility Polish

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-11 - Accessible Custom Radio Buttons with Tailwind
+**Learning:** When hiding native radio inputs to style custom interactive UI elements with Tailwind, using classes like `invisible`, `hidden`, or `w-0 absolute` removes them from the accessibility tree, breaking screen reader functionality. Additionally, without explicit keyboard focus styles on the visible parent element, keyboard users cannot navigate the interface.
+**Action:** Use the `sr-only` class to visually hide native inputs while preserving screen reader accessibility. Ensure keyboard focus is visible by adding styling to the parent `<label>` using Tailwind's `has-[:focus-visible]` modifier (e.g., `has-[:focus-visible]:ring-2`).

--- a/wordle/index.html
+++ b/wordle/index.html
@@ -69,23 +69,23 @@
 <header class="flex items-center px-4 py-3 justify-between border-b border-neutral-100 sticky top-0 z-10 bg-white/95 backdrop-blur-sm">
 <div class="size-10 shrink-0"></div>
 <h1 class="text-2xl md:text-3xl font-extrabold tracking-tight text-center flex-1">Endless Wordle</h1>
-<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary">
+<button class="flex size-10 shrink-0 items-center justify-center rounded-full hover:bg-neutral-100 transition-colors text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400" aria-label="Statistics">
 <span class="material-symbols-outlined text-[24px]">bar_chart</span>
 </button>
 </header>
 <div class="px-6 py-4">
 <div class="flex h-10 w-full items-center justify-center rounded-xl bg-neutral-100 p-1">
-<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200">
+<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-neutral-400">
 <span class="truncate text-xs font-bold uppercase tracking-wide">Easy</span>
-<input class="invisible w-0 absolute" name="difficulty" type="radio" value="Easy"/>
+<input class="sr-only" name="difficulty" type="radio" value="Easy"/>
 </label>
-<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200">
+<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-neutral-400">
 <span class="truncate text-xs font-bold uppercase tracking-wide">Medium</span>
-<input checked="" class="invisible w-0 absolute" name="difficulty" type="radio" value="Medium"/>
+<input checked="" class="sr-only" name="difficulty" type="radio" value="Medium"/>
 </label>
-<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200">
+<label class="flex cursor-pointer h-full grow items-center justify-center overflow-hidden rounded-lg px-2 has-[:checked]:bg-white has-[:checked]:shadow-sm text-neutral-500 has-[:checked]:text-black transition-all duration-200 has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-neutral-400">
 <span class="truncate text-xs font-bold uppercase tracking-wide">Hard</span>
-<input class="invisible w-0 absolute" name="difficulty" type="radio" value="Hard"/>
+<input class="sr-only" name="difficulty" type="radio" value="Hard"/>
 </label>
 </div>
 </div>
@@ -103,7 +103,7 @@
     <div class="bg-white rounded-lg shadow-xl w-full max-w-md mx-auto flex flex-col max-h-full">
         <div class="flex justify-between items-center p-6 border-b shrink-0">
             <h2 class="text-2xl font-bold">Statistics</h2>
-            <button id="close-stats" class="text-gray-500 hover:text-gray-800">
+            <button id="close-stats" class="text-gray-500 hover:text-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400 rounded-full p-1" aria-label="Close Statistics">
                 <span class="material-symbols-outlined">close</span>
             </button>
         </div>


### PR DESCRIPTION
### 🎨 Palette: Wordle Accessibility Polish

#### 💡 What
- Replaced the inaccessible `invisible` utility classes on the "Difficulty" radio inputs with Tailwind's `sr-only` class.
- Added explicit keyboard focus states (`focus-visible:ring-2`) to the difficulty labels and icon-only buttons.
- Added `aria-label` attributes to the "Statistics" and modal "Close" buttons.
- Created a `.jules/palette.md` journal entry to document the correct pattern for accessible custom radio buttons.

#### 🎯 Why
- Using `invisible` or `hidden` on a native `<input type="radio">` removes it entirely from the accessibility tree, meaning screen reader users are completely unaware the difficulty toggles exist. Using `sr-only` visually hides the input while keeping it semantically available.
- Without visible focus rings, keyboard users (who rely on the `Tab` key) cannot tell which element is currently active, making navigation difficult or impossible.

#### ♿ Accessibility
- Screen readers can now properly announce the difficulty radio buttons.
- Screen readers now announce the purpose of the "Statistics" and "Close" buttons.
- Keyboard-only users have clear visual feedback when tabbing through the interface.

---
*PR created automatically by Jules for task [17762947797398153114](https://jules.google.com/task/17762947797398153114) started by @wesdyer*