### PR TITLE
⚡ Bolt: Cache Wind sin/cos in getWindAt

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Caching Wind Sine/Cosine in Regatta
+**Learning:** In the `regatta` application, `getWindAt` is called extremely frequently per frame (for every boat, multiple times for collision projection, sail calculations, particle and wave physics, etc.). Inside `getWindAt`, `Math.sin(baseDir)` and `Math.cos(baseDir)` were calculated repeatedly, but `baseDir` (which is `state.wind.direction`) only changes once per frame in `updateBaseWind` (or occasionally from user interaction).
+**Action:** Cache `sinDir` and `cosDir` on `state.wind` whenever `state.wind.direction` is updated to eliminate redundant trigonometric operations across all entities.

--- a/regatta/js/script.js
+++ b/regatta/js/script.js
@@ -1752,6 +1752,8 @@ function updateBaseWind(dt) {
 
     state.wind.currentShift = newShiftDeg * (Math.PI / 180);
     state.wind.direction = normalizeAngle(state.wind.baseDirection + state.wind.currentShift);
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
 
     // Variability (Speed)
     const v = cond.variability !== undefined ? cond.variability : 0.5;
@@ -2091,9 +2093,9 @@ function getWindAt(x, y) {
     const baseSpeed = state.wind.speed;
     const baseDir = state.wind.direction;
 
-    // Convert to vector
-    let sumWx = Math.sin(baseDir) * baseSpeed;
-    let sumWy = -Math.cos(baseDir) * baseSpeed;
+    // Convert to vector using cached sin/cos
+    let sumWx = state.wind.sinDir * baseSpeed;
+    let sumWy = -state.wind.cosDir * baseSpeed;
 
     for (const g of state.gusts) {
         const dx = x - g.x;
@@ -3060,6 +3062,8 @@ if (UI.confIslandClustering) {
             const offset = state.race.conditions.directionBias || 0;
             state.wind.baseDirection = normalizeAngle(targetRad + offset);
             state.wind.direction = state.wind.baseDirection;
+            state.wind.sinDir = Math.sin(state.wind.direction);
+            state.wind.cosDir = Math.cos(state.wind.direction);
 
             // Re-init course to align with new wind
             initCourse();
@@ -7138,6 +7142,8 @@ function resetGame() {
     state.wind.speed = state.wind.baseSpeed;
     state.wind.baseDirection = Math.random() * Math.PI * 2;
     state.wind.direction = state.wind.baseDirection;
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
     state.wind.currentShift = 0;
     state.wind.oscillator = Math.random() * Math.PI * 2; // Random phase
     state.wind.history = [];


### PR DESCRIPTION
⚡ Bolt: Cache Wind sin/cos in getWindAt

💡 What: Cached the `Math.sin` and `Math.cos` of the base wind direction in the `state.wind` object, updated alongside the direction. Used these cached values inside the heavily called `getWindAt` function instead of recalculating them.
🎯 Why: `getWindAt` is called very frequently (per frame per boat, plus inside collision detection, particle generation, etc.). Recomputing the sine and cosine of the global wind direction, which only changes once per frame, is redundant and inefficient.
📊 Impact: Reduces trigonometric calculations by at least 2 calls per `getWindAt` invocation, saving hundreds of redundant Math operations per frame.
🔬 Measurement: Run `pnpm run eval:ai`. It should complete successfully with similar stats and zero errors, proving the math optimization preserves functionality exactly.

---
*PR created automatically by Jules for task [4437612207037537959](https://jules.google.com/task/4437612207037537959) started by @wesdyer*