### PR TITLE
⚡ Bolt: Cache trigonometric values in wind/gust loops to speed up getWindAt

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-02-18 - Pre-compute and cache trigonometric values for high-frequency queries
+**Learning:** In the `regatta` application, spatial queries like `getWindAt` are called thousands of times per frame (for every pixel of wake, for UI updates, for AI planning, etc.). Calculating `Math.sin()` and `Math.cos()` inside these high-frequency loops is a major performance bottleneck, especially when the inputs (wind direction, gust rotation) change relatively slowly.
+**Action:** Always pre-calculate and cache expensive trigonometric and division values (like `Math.sin(direction)` or `1 / (radius * radius)`) directly on the objects (e.g. `state.wind.sinDir`, `g.invRadiusXSq`) whenever they are updated, so that high-frequency functions can simply use vector multiplication.

--- a/regatta/js/script.js
+++ b/regatta/js/script.js
@@ -1744,6 +1744,8 @@ function updateBaseWind(dt) {
     // Total wind direction = base + oscillation + persistent drift.
     const persistRad = state.wind.persistentShift * (Math.PI / 180);
     state.wind.direction = normalizeAngle(state.wind.baseDirection + state.wind.currentShift + persistRad);
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
 
     // Variability (Speed)
     const v = cond.variability !== undefined ? cond.variability : 0.5;
@@ -2003,15 +2005,23 @@ function createGust(x, y, type, initial = false) {
     const duration = 90 + Math.random() * 150;
     const age = initial ? Math.random() * duration : 0;
 
+    const rot = windDir + dirDelta + Math.PI / 2;
+    const gwDir = state.wind.direction + dirDelta;
     return {
         type, x, y, vx, vy,
         moveSpeedFactor, moveDirOffset,
         maxRadiusX, maxRadiusY,
         radiusX: 10, radiusY: 10,
-        rotation: windDir + dirDelta + Math.PI / 2,
+        rotation: rot,
         speedDelta, dirDelta,
         duration,
-        age
+        age,
+        invRadiusXSq: 1/100,
+        invRadiusYSq: 1/100,
+        sinRot: Math.sin(-rot),
+        cosRot: Math.cos(-rot),
+        sinGwDir: Math.sin(gwDir),
+        cosGwDir: -Math.cos(gwDir)
     };
 }
 
@@ -2077,6 +2087,14 @@ function updateGusts(dt) {
         g.radiusX = Math.max(10, g.maxRadiusX * lifeFactor);
         g.radiusY = Math.max(10, g.maxRadiusY * lifeFactor);
 
+        g.invRadiusXSq = 1 / (g.radiusX * g.radiusX);
+        g.invRadiusYSq = 1 / (g.radiusY * g.radiusY);
+        g.sinRot = Math.sin(-g.rotation);
+        g.cosRot = Math.cos(-g.rotation);
+        const gwDir = state.wind.direction + g.dirDelta;
+        g.sinGwDir = Math.sin(gwDir);
+        g.cosGwDir = -Math.cos(gwDir);
+
         if (g.age > g.duration) {
             state.gusts.splice(i, 1);
         }
@@ -2086,21 +2104,19 @@ function updateGusts(dt) {
 function getWindAt(x, y) {
     // Current Global Wind
     const baseSpeed = state.wind.speed;
-    const baseDir = state.wind.direction;
 
     // Convert to vector
-    let sumWx = Math.sin(baseDir) * baseSpeed;
-    let sumWy = -Math.cos(baseDir) * baseSpeed;
+    let sumWx = state.wind.sinDir * baseSpeed;
+    let sumWy = -state.wind.cosDir * baseSpeed;
 
     for (const g of state.gusts) {
         const dx = x - g.x;
         const dy = y - g.y;
-        const cos = Math.cos(-g.rotation);
-        const sin = Math.sin(-g.rotation);
-        const rx = dx * cos - dy * sin;
-        const ry = dx * sin + dy * cos;
 
-        const distSq = (rx*rx)/(g.radiusX*g.radiusX) + (ry*ry)/(g.radiusY*g.radiusY);
+        const rx = dx * g.cosRot - dy * g.sinRot;
+        const ry = dx * g.sinRot + dy * g.cosRot;
+
+        const distSq = (rx*rx)*g.invRadiusXSq + (ry*ry)*g.invRadiusYSq;
         if (distSq <= 1) {
             const falloff = 1 - Math.sqrt(distSq);
             const lifeFade = Math.min(g.age / 5, 1) * Math.min((g.duration - g.age) / 5, 1);
@@ -2108,13 +2124,10 @@ function getWindAt(x, y) {
 
             if (intensity > 0) {
                  const gSpeed = g.speedDelta * intensity;
-                 // Local direction inside puff
-                 const gwDir = baseDir + g.dirDelta;
-
                  // Add puff vector
                  // Note: gSpeed can be negative (lull)
-                 sumWx += Math.sin(gwDir) * gSpeed;
-                 sumWy += -Math.cos(gwDir) * gSpeed;
+                 sumWx += g.sinGwDir * gSpeed;
+                 sumWy += g.cosGwDir * gSpeed;
             }
         }
     }
@@ -3057,6 +3070,8 @@ if (UI.confIslandClustering) {
             const offset = state.race.conditions.directionBias || 0;
             state.wind.baseDirection = normalizeAngle(targetRad + offset);
             state.wind.direction = state.wind.baseDirection;
+            state.wind.sinDir = Math.sin(state.wind.direction);
+            state.wind.cosDir = Math.cos(state.wind.direction);
 
             // Re-init course to align with new wind
             initCourse();
@@ -7242,6 +7257,8 @@ function resetGame() {
     state.wind.speed = state.wind.baseSpeed;
     state.wind.baseDirection = Math.random() * Math.PI * 2;
     state.wind.direction = state.wind.baseDirection;
+    state.wind.sinDir = Math.sin(state.wind.direction);
+    state.wind.cosDir = Math.cos(state.wind.direction);
     state.wind.currentShift = 0;
     state.wind.oscillator = Math.random() * Math.PI * 2; // Random phase
     state.wind.history = [];


### PR DESCRIPTION
⚡ Bolt: Cache trigonometric values in wind/gust loops to speed up getWindAt

💡 What:
- Added caching for `sinDir` and `cosDir` in `state.wind`.
- Added caching for `invRadiusXSq`, `invRadiusYSq`, `sinRot`, `cosRot`, `sinGwDir`, and `cosGwDir` on gust objects in `updateGusts` and `spawnGlobalGust`.
- Refactored `getWindAt` to use these pre-calculated values.

🎯 Why:
- `getWindAt` is called thousands of times per frame (rendering wake, AI calculations, wind shadow casting, UI updates).
- Recalculating `Math.sin`, `Math.cos` and division inside this high-frequency loop creates a severe performance bottleneck.
- By caching these values when the relatively slow-moving wind and gusts update once per frame, we avoid redundant calculations.

📊 Impact:
- Eliminates 4 trig calls and 2 divisions per gust * per point checked in `getWindAt`.
- Expected to significantly reduce JS execution time during complex races with many gusts, stabilizing framerates.

🔬 Measurement:
- Playwright simulation runs fine (`pnpm run eval:ai`). No regressions introduced.

---
*PR created automatically by Jules for task [4771812513750075099](https://jules.google.com/task/4771812513750075099) started by @wesdyer*